### PR TITLE
add some automagic to handling projects, milestones, and labels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: go
+go:
+- 1.8

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
 run: deps
+	go env
 	go run *.go
 
 deps:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 run: deps
 	go env
+	env | grep GITHUB
 	go run *.go
 
 deps:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+
+run: deps
+	go run *.go
+
+deps:
+	go get gopkg.in/yaml.v2
+	go get github.com/shawncatz/go-github/github
+	# TODO: change to 'go get github.com/google/go-github/github' after PR merged
+
+.PHONY: run deps

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ run: deps
 
 deps:
 	go get -u gopkg.in/yaml.v2
-	go get -u github.com/shawncatz/go-github/github
-	# TODO: change to 'go get github.com/google/go-github/github' after PR merged
+	go get -u github.com/google/go-github/github
 
 .PHONY: run deps

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ run: deps
 	go run *.go
 
 deps:
-	go get gopkg.in/yaml.v2
-	go get github.com/shawncatz/go-github/github
+	go get -u gopkg.in/yaml.v2
+	go get -u github.com/shawncatz/go-github/github
 	# TODO: change to 'go get github.com/google/go-github/github' after PR merged
 
 .PHONY: run deps

--- a/config.go
+++ b/config.go
@@ -29,6 +29,9 @@ type Config struct {
 	Repos      []string
 	Milestones []Milestone
 	Labels     []Label
+	Project    struct {
+		Columns []string
+	}
 }
 
 type Milestone struct {

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ func loadConfig() error {
 	return nil
 }
 
+// Config contains the data in config.yml
 type Config struct {
 	Repos      []string
 	Milestones []Milestone
@@ -34,16 +35,19 @@ type Config struct {
 	}
 }
 
+// Milestone contains the milestones from config.yml
 type Milestone struct {
 	Date    string
 	Version string
 }
 
+// Label contains the labels from config.yml
 type Label struct {
 	Name  string
 	Color string
 }
 
+// Milestone finds the milestone with the given name from the config
 func (c *Config) Milestone(name string) bool {
 	for _, m := range c.Milestones {
 		if m.Version == name {

--- a/config.go
+++ b/config.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+)
+
+func loadConfig() error {
+	config = &Config{}
+	var err error
+	var data []byte
+
+	data, err = ioutil.ReadFile(FILE)
+	if err != nil {
+		return fmt.Errorf("error reading file: %s", err)
+	}
+
+	err = yaml.Unmarshal([]byte(data), &config)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling yaml: %v", err)
+	}
+
+	return nil
+}
+
+type Config struct {
+	Repos      []string
+	Milestones []Milestone
+	Labels     []Label
+}
+
+type Milestone struct {
+	Date    string
+	Version string
+}
+
+type Label struct {
+	Name  string
+	Color string
+}
+
+func (c *Config) Milestone(name string) bool {
+	for _, m := range c.Milestones {
+		if m.Version == name {
+			return true
+		}
+	}
+
+	return false
+}

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,50 @@
+repos:
+  - revel
+  - cmd
+  - modules
+  - examples
+
+milestones:
+  - version: Backlog
+  - version: v0.14
+    date: 2017-03-31
+  - version: v0.15
+    date: 2017-04-30
+  - version: v0.16
+    date: 2017-05-31
+
+labels:
+  - name: effort-days
+    color: 207de5 # blue
+  - name: effort-hours
+    color: 207de5
+  - name: effort-minutes
+    color: 207de5
+
+  - name: priority-could
+    color: 5319e7 # purple
+  - name: priority-should
+    color: 5319e7
+  - name: priority-must
+    color: 5319e7
+
+  - name: status-accepted
+    color: 009800 # green
+  - name: status-analysis
+    color: eb6420 # orange
+  - name: status-declined
+    color: e11d21 # red
+  - name: status-waiting-for-reply
+    color: eb6420 # orange
+
+  - name: type-bug
+    color: e11d21 # red
+  - name: type-bug-windows
+    color: e11d21 # red
+  - name: type-docs
+    color: 207de5 # blue
+  - name: type-enhancement
+    color: 207de5 # blue
+  - name: type-feature
+    color: 207de5 # blue
+

--- a/config.yml
+++ b/config.yml
@@ -4,6 +4,13 @@ repos:
   - modules
   - examples
 
+project:
+  columns:
+    - todo
+    - in progress
+    - in review
+    - complete
+
 milestones:
   - version: Backlog
   - version: v0.14

--- a/git.go
+++ b/git.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/shawncatz/go-github/github"
-	"time"
 )
 
 func loadGithub() error {

--- a/git.go
+++ b/git.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/shawncatz/go-github/github"
+)
+
+func loadGithub() error {
+	username := "shawncatz"
+	password := os.Getenv("GITHUB_TOKEN")
+
+	tp := github.BasicAuthTransport{
+		Username: username,
+		Password: password,
+	}
+
+	client = github.NewClient(tp.Client())
+	ctx = context.Background()
+
+	git = &Git{Repos: make(map[string]GitRepo)}
+
+	projects, _, err := client.Organizations.ListProjects(ctx, "revel", &github.ProjectListOptions{})
+	if err != nil {
+		return err
+	}
+
+	git.Projects = projects
+
+	for _, r := range config.Repos {
+		list, _, err := client.Issues.ListMilestones(ctx, "revel", r, &github.MilestoneListOptions{})
+		if err != nil {
+			return err
+		}
+
+		gr := GitRepo{}
+
+		gr.Milestones = list
+
+		labels, err := getLabels(r)
+		if err != nil {
+			return err
+		}
+
+		gr.Labels = labels
+
+		git.Repos[r] = gr
+	}
+
+	return nil
+}
+
+// getLabels returns a combined slice of labels from paged responses
+// some repos might have more labels than fit in a single page
+func getLabels(repo string) ([]*github.Label, error) {
+	out := []*github.Label{}
+	page := 1
+	lastpage := 0
+
+	for ok := true; ok; ok = (page == lastpage) {
+		labels, resp, err := client.Issues.ListLabels(ctx, "revel", repo, &github.ListOptions{Page: page})
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, labels...) // ... breaks the slice into variadic parameters
+		lastpage = resp.LastPage
+		page++
+	}
+
+	return out, nil
+}
+
+type Git struct {
+	// list of organization projects
+	Projects []*github.Project
+	// map of repo name to repo object
+	Repos map[string]GitRepo
+}
+
+type GitRepo struct {
+	Milestones []*github.Milestone
+	Labels     []*github.Label
+}
+
+func (g *Git) Project(name string) *github.Project {
+	for _, p := range g.Projects {
+		if *p.Name == name {
+			return p
+		}
+	}
+
+	return nil
+}
+
+func (g *Git) Milestone(repo, name string) *github.Milestone {
+	for _, m := range g.Repos[repo].Milestones {
+		if *m.Title == name {
+			return m
+		}
+	}
+
+	return nil
+}
+
+func (g *Git) Label(repo, name string) *github.Label {
+	for _, m := range g.Repos[repo].Labels {
+		if *m.Name == name {
+			return m
+		}
+	}
+
+	return nil
+}
+
+func (g *Git) String() string {
+	s := ""
+
+	s += "Projects:\n"
+	for _, p := range g.Projects {
+		s += fmt.Sprintf("  %d '%s'\n", p.ID, *p.Name)
+	}
+
+	s += "Repos:\n"
+	for _, r := range config.Repos {
+		s += "  " + r + "\n"
+		s += "    milestones:\n"
+		for _, m := range g.Repos[r].Milestones {
+			s += "      " + *m.Title
+			if m.DueOn != nil {
+				s += " " + m.DueOn.String()
+			}
+			s += "\n"
+		}
+		s += "    labels:\n"
+		for _, l := range g.Repos[r].Labels {
+			s += "      " + *l.Name + " " + *l.Color + "\n"
+		}
+	}
+
+	return s
+}

--- a/git.go
+++ b/git.go
@@ -74,6 +74,7 @@ func getLabels(repo string) ([]*github.Label, error) {
 	return out, nil
 }
 
+// Git stores the information retrieved from github
 type Git struct {
 	// list of organization projects
 	Projects []*github.Project
@@ -81,11 +82,13 @@ type Git struct {
 	Repos map[string]GitRepo
 }
 
+// GitRepo stores the repo information from github
 type GitRepo struct {
 	Milestones []*github.Milestone
 	Labels     []*github.Label
 }
 
+// Project finds a project with the given name
 func (g *Git) Project(name string) *github.Project {
 	for _, p := range g.Projects {
 		if *p.Name == name {
@@ -96,6 +99,7 @@ func (g *Git) Project(name string) *github.Project {
 	return nil
 }
 
+// Milestone finds a milestone with the given repo and name
 func (g *Git) Milestone(repo, name string) *github.Milestone {
 	for _, m := range g.Repos[repo].Milestones {
 		if *m.Title == name {
@@ -106,6 +110,7 @@ func (g *Git) Milestone(repo, name string) *github.Milestone {
 	return nil
 }
 
+// Label finds a label with the given repo and name
 func (g *Git) Label(repo, name string) *github.Label {
 	for _, m := range g.Repos[repo].Labels {
 		if *m.Name == name {
@@ -116,6 +121,7 @@ func (g *Git) Label(repo, name string) *github.Label {
 	return nil
 }
 
+// String returns the Git object as a string
 func (g *Git) String() string {
 	s := ""
 
@@ -144,7 +150,7 @@ func (g *Git) String() string {
 	return s
 }
 
-func CreateProject(name, desc string) (*github.Project, error) {
+func createProject(name, desc string) (*github.Project, error) {
 	project, _, err := client.Organizations.CreateProject(ctx, ORG, &github.ProjectOptions{Name: name, Body: desc})
 	if err != nil {
 		return nil, err
@@ -160,7 +166,7 @@ func CreateProject(name, desc string) (*github.Project, error) {
 	return project, nil
 }
 
-func CreateMilestone(repo, name, date string) (*github.Milestone, error) {
+func createMilestone(repo, name, date string) (*github.Milestone, error) {
 	opt := &github.Milestone{Title: &name}
 	if date != "" {
 		t, err := time.Parse("2006-01-02", date)
@@ -178,7 +184,7 @@ func CreateMilestone(repo, name, date string) (*github.Milestone, error) {
 	return m, nil
 }
 
-func CreateLabel(repo, name, color string) (*github.Label, error) {
+func createLabel(repo, name, color string) (*github.Label, error) {
 	opt := &github.Label{Name: &name, Color: &color}
 
 	l, _, err := client.Issues.CreateLabel(ctx, ORG, repo, opt)

--- a/git.go
+++ b/git.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/shawncatz/go-github/github"
+	"github.com/google/go-github/github"
 )
 
 func loadGithub() error {

--- a/main.go
+++ b/main.go
@@ -1,9 +1,5 @@
 package main
 
-// go get gopkg.in/yaml.v2
-// go get github.com/shawncatz/go-github/github
-// TODO: change to 'go get github.com/google/go-github/github' after PR merged
-
 import (
 	"context"
 	"fmt"

--- a/main.go
+++ b/main.go
@@ -1,0 +1,248 @@
+package main
+
+// go get gopkg.in/yaml.v2
+// go get github.com/shawncatz/go-github/github
+// TODO: change to 'go get github.com/google/go-github/github' after PR merged
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	// TODO: change this once PR is merged: https://github.com/google/go-github/pull/599
+	"github.com/shawncatz/go-github/github"
+	"gopkg.in/yaml.v2"
+)
+
+const FILE = "config.yml"
+
+var (
+	ctx    context.Context
+	client *github.Client
+	config *Config
+	git    *Git
+)
+
+type Config struct {
+	Repos      []string
+	Milestones []Milestone
+	Labels     []Label
+}
+
+type Milestone struct {
+	Date    string
+	Version string
+}
+
+type Label struct {
+	Name  string
+	Color string
+}
+
+func (c *Config) Milestone(name string) bool {
+	for _, m := range c.Milestones {
+		if m.Version == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+type Git struct {
+	// list of organization projects
+	Projects []*github.Project
+	// map of repo name to repo object
+	Repos map[string]GitRepo
+}
+
+type GitRepo struct {
+	Milestones []*github.Milestone
+	Labels     []*github.Label
+}
+
+func (g *Git) Project(name string) *github.Project {
+	for _, p := range g.Projects {
+		if *p.Name == name {
+			return p
+		}
+	}
+
+	return nil
+}
+
+func (g *Git) Milestone(repo, name string) *github.Milestone {
+	for _, m := range g.Repos[repo].Milestones {
+		if *m.Title == name {
+			return m
+		}
+	}
+
+	return nil
+}
+
+func (g *Git) Label(repo, name string) *github.Label {
+	for _, m := range g.Repos[repo].Labels {
+		if *m.Name == name {
+			return m
+		}
+	}
+
+	return nil
+}
+
+func (g *Git) String() string {
+	s := ""
+
+	s += "Projects:\n"
+	for _, p := range g.Projects {
+		s += fmt.Sprintf("  %d '%s'\n", p.ID, *p.Name)
+	}
+
+	s += "Repos:\n"
+	for _, r := range config.Repos {
+		s += "  " + r + "\n"
+		s += "    milestones:\n"
+		for _, m := range g.Repos[r].Milestones {
+			s += "      " + *m.Title
+			if m.DueOn != nil {
+				s += " " + m.DueOn.String()
+			}
+			s += "\n"
+		}
+		s += "    labels:\n"
+		for _, l := range g.Repos[r].Labels {
+			s += "      " + *l.Name + " " + *l.Color + "\n"
+		}
+	}
+
+	return s
+}
+
+func init() {
+	if err := loadConfig(); err != nil {
+		log.Fatalf("error loading config: %s", err)
+	}
+
+	if err := loadGithub(); err != nil {
+		log.Fatalf("error loading github: %s", err)
+	}
+}
+
+func loadGithub() error {
+	username := "shawncatz"
+	password := os.Getenv("GITHUB_TOKEN")
+
+	tp := github.BasicAuthTransport{
+		Username: strings.TrimSpace(username),
+		Password: strings.TrimSpace(password),
+	}
+
+	client = github.NewClient(tp.Client())
+	ctx = context.Background()
+
+	git = &Git{Repos: make(map[string]GitRepo)}
+
+	projects, _, err := client.Organizations.ListProjects(ctx, "revel", &github.ListProjectsOptions{})
+	if err != nil {
+		return err
+	}
+
+	git.Projects = projects
+
+	for _, r := range config.Repos {
+		list, _, err := client.Issues.ListMilestones(ctx, "revel", r, &github.MilestoneListOptions{})
+		if err != nil {
+			return err
+		}
+
+		gr := GitRepo{}
+
+		gr.Milestones = list
+
+		labels, _, err := client.Issues.ListLabels(ctx, "revel", r, &github.ListOptions{})
+		if err != nil {
+			return err
+		}
+
+		gr.Labels = labels
+
+		git.Repos[r] = gr
+	}
+
+	return nil
+}
+
+func loadConfig() error {
+	config = &Config{}
+	var err error
+	var data []byte
+
+	data, err = ioutil.ReadFile(FILE)
+	if err != nil {
+		return fmt.Errorf("error reading file: %s", err)
+	}
+
+	err = yaml.Unmarshal([]byte(data), &config)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling yaml: %v", err)
+	}
+
+	return nil
+}
+
+//func listProjects() ([]*github.Project, error) {
+//	projects, _, err := client.Organizations.ListProjects(ctx, "revel", &github.ListProjectsOptions{})
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	//for _, p := range projects {
+//	//  fmt.Printf("%d %s\n", p.ID, *p.Name)
+//	//}
+//
+//	return projects, nil
+//}
+//
+//func listMilestones(repo string) ([]*github.Milestone, error) {
+//	list, _, err := client.Issues.ListMilestones(ctx, "revel", repo, &github.MilestoneListOptions{})
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	return list, nil
+//}
+
+func main() {
+	//fmt.Printf("config: %#v\n", config)
+	fmt.Printf(git.String())
+
+	for _, m := range config.Milestones {
+		if m.Version == "Backlog" {
+			continue
+		}
+		p := git.Project(m.Version)
+		if p == nil {
+			fmt.Printf("create project on org: %s\n", m.Version)
+		}
+	}
+
+	for _, r := range config.Repos {
+		for _, m := range config.Milestones {
+			gm := git.Milestone(r, m.Version)
+			if gm == nil {
+				fmt.Printf("create milestone %s on repo %s\n", m.Version, r)
+			}
+		}
+
+		for _, l := range config.Labels {
+			gl := git.Label(r, l.Name)
+			if gl == nil {
+				fmt.Printf("create label %s on repo %s\n", l.Name, r)
+			}
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -35,19 +35,23 @@ func main() {
 	//fmt.Printf("config: %#v\n", config)
 	//fmt.Printf(git.String())
 
-	for _, m := range config.Milestones {
-		if m.Version == "Backlog" {
-			continue
-		}
-		p := git.Project(m.Version)
-		if p == nil {
-			fmt.Printf("create project on org: %s\n", m.Version)
-			_, err := createProject(m.Version, "Collect all work for "+m.Version)
-			if err != nil {
-				log.Fatalf("error creating project: %s", err)
-			}
-		}
-	}
+	// disabling this for now...
+	// the GitHub Org Projects do not work very well.
+	// using waffle.io instead.
+	//
+	//for _, m := range config.Milestones {
+	//	if m.Version == "Backlog" {
+	//		continue
+	//	}
+	//	p := git.Project(m.Version)
+	//	if p == nil {
+	//		fmt.Printf("create project on org: %s\n", m.Version)
+	//		_, err := createProject(m.Version, "Collect all work for "+m.Version)
+	//		if err != nil {
+	//			log.Fatalf("error creating project: %s", err)
+	//		}
+	//	}
+	//}
 
 	for _, r := range config.Repos {
 		for _, m := range config.Milestones {

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 )
 
 const FILE = "config.yml"
+const ORG = "revel"
 
 var (
 	ctx    context.Context
@@ -42,6 +43,10 @@ func main() {
 		p := git.Project(m.Version)
 		if p == nil {
 			fmt.Printf("create project on org: %s\n", m.Version)
+			_, err := CreateProject(m.Version, "Collect all work for "+m.Version)
+			if err != nil {
+				log.Fatalf("error creating project: %s", err)
+			}
 		}
 	}
 
@@ -50,6 +55,10 @@ func main() {
 			gm := git.Milestone(r, m.Version)
 			if gm == nil {
 				fmt.Printf("create milestone %s on repo %s\n", m.Version, r)
+				_, err := CreateMilestone(r, m.Version, m.Date)
+				if err != nil {
+					log.Fatalf("error creating milestone: %s", err)
+				}
 			}
 		}
 
@@ -57,6 +66,10 @@ func main() {
 			gl := git.Label(r, l.Name)
 			if gl == nil {
 				fmt.Printf("create label %s on repo %s\n", l.Name, r)
+				_, err := CreateLabel(r, l.Name, l.Color)
+				if err != nil {
+					log.Fatalf("error creating label: %s", err)
+				}
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -8,7 +8,10 @@ import (
 	"github.com/shawncatz/go-github/github"
 )
 
+// FILE is the location of the config.yml file
 const FILE = "config.yml"
+
+// ORG is the name of the organization
 const ORG = "revel"
 
 var (
@@ -39,7 +42,7 @@ func main() {
 		p := git.Project(m.Version)
 		if p == nil {
 			fmt.Printf("create project on org: %s\n", m.Version)
-			_, err := CreateProject(m.Version, "Collect all work for "+m.Version)
+			_, err := createProject(m.Version, "Collect all work for "+m.Version)
 			if err != nil {
 				log.Fatalf("error creating project: %s", err)
 			}
@@ -51,7 +54,7 @@ func main() {
 			gm := git.Milestone(r, m.Version)
 			if gm == nil {
 				fmt.Printf("create milestone %s on repo %s\n", m.Version, r)
-				_, err := CreateMilestone(r, m.Version, m.Date)
+				_, err := createMilestone(r, m.Version, m.Date)
 				if err != nil {
 					log.Fatalf("error creating milestone: %s", err)
 				}
@@ -62,7 +65,7 @@ func main() {
 			gl := git.Label(r, l.Name)
 			if gl == nil {
 				fmt.Printf("create label %s on repo %s\n", l.Name, r)
-				_, err := CreateLabel(r, l.Name, l.Color)
+				_, err := createLabel(r, l.Name, l.Color)
 				if err != nil {
 					log.Fatalf("error creating label: %s", err)
 				}

--- a/main.go
+++ b/main.go
@@ -7,14 +7,9 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
-	"os"
-	"strings"
 
-	// TODO: change this once PR is merged: https://github.com/google/go-github/pull/599
 	"github.com/shawncatz/go-github/github"
-	"gopkg.in/yaml.v2"
 )
 
 const FILE = "config.yml"
@@ -26,102 +21,6 @@ var (
 	git    *Git
 )
 
-type Config struct {
-	Repos      []string
-	Milestones []Milestone
-	Labels     []Label
-}
-
-type Milestone struct {
-	Date    string
-	Version string
-}
-
-type Label struct {
-	Name  string
-	Color string
-}
-
-func (c *Config) Milestone(name string) bool {
-	for _, m := range c.Milestones {
-		if m.Version == name {
-			return true
-		}
-	}
-
-	return false
-}
-
-type Git struct {
-	// list of organization projects
-	Projects []*github.Project
-	// map of repo name to repo object
-	Repos map[string]GitRepo
-}
-
-type GitRepo struct {
-	Milestones []*github.Milestone
-	Labels     []*github.Label
-}
-
-func (g *Git) Project(name string) *github.Project {
-	for _, p := range g.Projects {
-		if *p.Name == name {
-			return p
-		}
-	}
-
-	return nil
-}
-
-func (g *Git) Milestone(repo, name string) *github.Milestone {
-	for _, m := range g.Repos[repo].Milestones {
-		if *m.Title == name {
-			return m
-		}
-	}
-
-	return nil
-}
-
-func (g *Git) Label(repo, name string) *github.Label {
-	for _, m := range g.Repos[repo].Labels {
-		if *m.Name == name {
-			return m
-		}
-	}
-
-	return nil
-}
-
-func (g *Git) String() string {
-	s := ""
-
-	s += "Projects:\n"
-	for _, p := range g.Projects {
-		s += fmt.Sprintf("  %d '%s'\n", p.ID, *p.Name)
-	}
-
-	s += "Repos:\n"
-	for _, r := range config.Repos {
-		s += "  " + r + "\n"
-		s += "    milestones:\n"
-		for _, m := range g.Repos[r].Milestones {
-			s += "      " + *m.Title
-			if m.DueOn != nil {
-				s += " " + m.DueOn.String()
-			}
-			s += "\n"
-		}
-		s += "    labels:\n"
-		for _, l := range g.Repos[r].Labels {
-			s += "      " + *l.Name + " " + *l.Color + "\n"
-		}
-	}
-
-	return s
-}
-
 func init() {
 	if err := loadConfig(); err != nil {
 		log.Fatalf("error loading config: %s", err)
@@ -132,93 +31,9 @@ func init() {
 	}
 }
 
-func loadGithub() error {
-	username := "shawncatz"
-	password := os.Getenv("GITHUB_TOKEN")
-
-	tp := github.BasicAuthTransport{
-		Username: strings.TrimSpace(username),
-		Password: strings.TrimSpace(password),
-	}
-
-	client = github.NewClient(tp.Client())
-	ctx = context.Background()
-
-	git = &Git{Repos: make(map[string]GitRepo)}
-
-	projects, _, err := client.Organizations.ListProjects(ctx, "revel", &github.ListProjectsOptions{})
-	if err != nil {
-		return err
-	}
-
-	git.Projects = projects
-
-	for _, r := range config.Repos {
-		list, _, err := client.Issues.ListMilestones(ctx, "revel", r, &github.MilestoneListOptions{})
-		if err != nil {
-			return err
-		}
-
-		gr := GitRepo{}
-
-		gr.Milestones = list
-
-		labels, _, err := client.Issues.ListLabels(ctx, "revel", r, &github.ListOptions{})
-		if err != nil {
-			return err
-		}
-
-		gr.Labels = labels
-
-		git.Repos[r] = gr
-	}
-
-	return nil
-}
-
-func loadConfig() error {
-	config = &Config{}
-	var err error
-	var data []byte
-
-	data, err = ioutil.ReadFile(FILE)
-	if err != nil {
-		return fmt.Errorf("error reading file: %s", err)
-	}
-
-	err = yaml.Unmarshal([]byte(data), &config)
-	if err != nil {
-		return fmt.Errorf("error unmarshaling yaml: %v", err)
-	}
-
-	return nil
-}
-
-//func listProjects() ([]*github.Project, error) {
-//	projects, _, err := client.Organizations.ListProjects(ctx, "revel", &github.ListProjectsOptions{})
-//	if err != nil {
-//		return nil, err
-//	}
-//
-//	//for _, p := range projects {
-//	//  fmt.Printf("%d %s\n", p.ID, *p.Name)
-//	//}
-//
-//	return projects, nil
-//}
-//
-//func listMilestones(repo string) ([]*github.Milestone, error) {
-//	list, _, err := client.Issues.ListMilestones(ctx, "revel", repo, &github.MilestoneListOptions{})
-//	if err != nil {
-//		return nil, err
-//	}
-//
-//	return list, nil
-//}
-
 func main() {
 	//fmt.Printf("config: %#v\n", config)
-	fmt.Printf(git.String())
+	//fmt.Printf(git.String())
 
 	for _, m := range config.Milestones {
 		if m.Version == "Backlog" {

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/shawncatz/go-github/github"
+	"github.com/google/go-github/github"
 )
 
 // FILE is the location of the config.yml file


### PR DESCRIPTION
the `config.yml` file contains a list of repositories, milestones, and labels
the `main.go` program does the following:
* ensure that each listed milestone has a corresponding organization project (to collect all of the work for a milestone in a single view)
* ensure that each repo has the each of the labels and milestones

currently, it does not update existing labels and milestones, if they exist, it moves on.
it should be able to handle updating labels and milestones as well (so that we can change the due date of a milestone in the config and it will update across all repos)

This is still a work in progress